### PR TITLE
Fix how permission level is being set

### DIFF
--- a/consts/errors.go
+++ b/consts/errors.go
@@ -33,6 +33,7 @@ const (
 	MsgErrGeneratingEmailVerifyLink string = "failed to generate email verfication link:"
 	MsgErrDeletingEmailToken        string = "failed to delete email token:"
 	MsgErrRetrieveEmailTokenRow     string = "failed to retrieve matched email token row"
+	MsgErrUpdatePermLevel           string = "failed to update permission level of user:"
 )
 
 var (

--- a/service/utility.go
+++ b/service/utility.go
@@ -28,7 +28,7 @@ const (
 )
 
 var (
-	tokenLocker         sync.Mutex
+	keyGenLocker        sync.Mutex
 	uuidLocker          sync.Mutex
 	multiSpaceRegex     = regexp.MustCompile(`[\s\p{Zs}]{2,}`)
 	nameValidCharsRegex = regexp.MustCompile(`^[[:alpha:]]+((['.\s-][[:alpha:]\s])?[[:alpha:]]*)*$`)
@@ -166,8 +166,8 @@ func generateSecretKey(tokenSize int) (string, error) {
 		return "", consts.ErrInvalidTokenSize
 	}
 
-	tokenLocker.Lock()
-	defer tokenLocker.Unlock()
+	keyGenLocker.Lock()
+	defer keyGenLocker.Unlock()
 
 	randomBytes := make([]byte, tokenSize)
 	_, err := cryptorand.Read(randomBytes)


### PR DESCRIPTION
closes #107 

VerifyEmailToken will change again for issue #108 

- CreateUser defaults permission level to NO_PERM
- implemented and unit tested updatePermissionLevel db utility
- renamed secretLocker to readSecretLocker
- renamed tokenLocker to keyGenLocker
- VerifyEmailToken updates permission level if token is valid
- updated CreateUser and VerifyEmailToken unit test to include testing for permission level changes