### PR TITLE
Make JSON Email Token for verifying user's email

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.7.0 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190310103314-d5245c3ac7ad
-	github.com/hwsc-org/hwsc-lib v0.0.0-20190310104150-51f502b2e5cc
+	github.com/hwsc-org/hwsc-lib v0.0.0-20190401004322-783e42349378
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/lib/pq v1.0.0
 	github.com/micro/go-config v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,14 @@ github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190310103314-d5245c3ac7ad h1:fWzDe7
 github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190310103314-d5245c3ac7ad/go.mod h1:/iVVgMsaXIOevC15fCsGWI0Dx2p6POFJQxeYbyjGst0=
 github.com/hwsc-org/hwsc-lib v0.0.0-20190310104150-51f502b2e5cc h1:uwnFS4r85zMd8zM141P2d4hqCrmUPumuNFZpXoIgY6w=
 github.com/hwsc-org/hwsc-lib v0.0.0-20190310104150-51f502b2e5cc/go.mod h1:x+Jk9oHb+7qbcHBKNUkJogQdM2D2BuLXbQ5wsGIiK4E=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190331065020-ea53397bd51f h1:hwMbe+3E0lM2eYzeSAXiFFAz4NgaBqzD7Xmdf3Rbbes=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190331065020-ea53397bd51f/go.mod h1:x+Jk9oHb+7qbcHBKNUkJogQdM2D2BuLXbQ5wsGIiK4E=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190331232933-5620b55ff2c9 h1:rULV5czgClwmJU8b0jOmlKd2vCLFFlfc+uc3f2RqJqo=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190331232933-5620b55ff2c9/go.mod h1:x+Jk9oHb+7qbcHBKNUkJogQdM2D2BuLXbQ5wsGIiK4E=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190331234926-a1a8092ce613 h1:Kl6etvSNV1PB0z89W2iWrIKzv4sqeRUnFA4l6omCmIQ=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190331234926-a1a8092ce613/go.mod h1:x+Jk9oHb+7qbcHBKNUkJogQdM2D2BuLXbQ5wsGIiK4E=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190401004322-783e42349378 h1:J2ADkUKYjEvOiwacTm8RXjpBThtd75Cg9Trv4zaORXE=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190401004322-783e42349378/go.mod h1:x+Jk9oHb+7qbcHBKNUkJogQdM2D2BuLXbQ5wsGIiK4E=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/service/service.go
+++ b/service/service.go
@@ -718,6 +718,7 @@ func (s *Service) VerifyEmailToken(ctx context.Context, req *pbsvc.UserRequest) 
 
 	uuid := auth.ExtractUUID(emailToken)
 	if uuid == "" {
+		logger.Error(consts.VerifyEmailToken, authconst.ErrInvalidUUID.Error())
 		return nil, consts.ErrStatusUUIDInvalid
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -44,12 +44,6 @@ var (
 	serviceStateLocker stateLocker
 	uuidMapLocker      sync.Map
 	secretLocker       sync.RWMutex
-
-	// converts the state of the service to a string
-	serviceStateMap = map[state]string{
-		available:   "Available",
-		unavailable: "Unavailable",
-	}
 )
 
 func init() {
@@ -127,52 +121,58 @@ func (s *Service) CreateUser(ctx context.Context, req *pbsvc.UserRequest) (*pbsv
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// from here on: do not return an error because we can always regenerate tokens and resend verification emails
-
-	// create unique email token
-	emailToken, err := generateSecretKey(emailTokenByteSize)
-	if err != nil {
-		logger.Error(consts.CreateUserTag, consts.MsgErrGeneratingEmailToken, err.Error())
-	}
-
-	// insert token into db, if nondb error returns, token will simply expire, so no need to remove
-	if err := insertEmailToken(user.GetUuid(), emailToken); err != nil {
-		logger.Error(consts.CreateUserTag, consts.MsgErrInsertEmailToken, err.Error())
-	}
-
-	// generate verficiation link for emails
-	verificationLink, err := generateEmailVerifyLink(emailToken)
-	if err != nil {
-		logger.Error(consts.CreateUserTag, consts.MsgErrGeneratingEmailVerifyLink, err.Error())
-	}
-
-	// send email
-	emailData := make(map[string]string)
-	if verificationLink != "" {
-		emailData[verificationLinkKey] = verificationLink
-	}
-
-	emailReq, err := newEmailRequest(emailData, []string{user.GetEmail()}, conf.EmailHost.Username, subjectVerifyEmail)
-	if err != nil {
-		logger.Error(consts.CreateUserTag, consts.MsgErrEmailRequest, err.Error())
-	}
-
-	if err := emailReq.sendEmail(templateVerifyEmail); err != nil {
-		logger.Error(consts.CreateUserTag, consts.MsgErrSendEmail, err.Error())
-	}
-
 	logger.Info("Inserted new user:", user.GetUuid(), user.GetFirstName(), user.GetLastName())
 
 	user.Password = ""
 	user.IsVerified = false
 	user.PermissionLevel = auth.PermissionStringMap[auth.NoPermission]
 
-	return &pbsvc.UserResponse{
-		Status:         &pbsvc.UserResponse_Code{Code: uint32(codes.OK)},
-		Message:        codes.OK.String(),
-		User:           user,
-		Identification: &pblib.Identification{Token: emailToken},
-	}, nil
+	userCreatedResponse := &pbsvc.UserResponse{
+		Status:  &pbsvc.UserResponse_Code{Code: uint32(codes.OK)},
+		Message: codes.OK.String(),
+		User:    user,
+	}
+
+	// from here on: do not return an error because we can always regenerate tokens and resend verification emails
+
+	// create identification for email token
+	emailID, err := generateEmailToken(user.GetUuid(), user.PermissionLevel)
+	if err != nil {
+		logger.Error(consts.CreateUserTag, consts.MsgErrGeneratingEmailToken, err.Error())
+		return userCreatedResponse, nil
+	}
+
+	// insert token into db, if nondb error returns, token will simply expire, so no need to remove
+	if err := insertEmailToken(user.GetUuid(), emailID.GetToken(), emailID.GetSecret()); err != nil {
+		logger.Error(consts.CreateUserTag, consts.MsgErrInsertEmailToken, err.Error())
+		return userCreatedResponse, nil
+	}
+
+	// generate verification link for emails
+	verificationLink, err := generateEmailVerifyLink(emailID.GetToken())
+	if err != nil {
+		logger.Error(consts.CreateUserTag, consts.MsgErrGeneratingEmailVerifyLink, err.Error())
+		return userCreatedResponse, nil
+	}
+
+	// send email
+	emailData := make(map[string]string)
+	if verificationLink == "" {
+		return userCreatedResponse, nil
+	}
+	emailData[verificationLinkKey] = verificationLink
+
+	emailReq, err := newEmailRequest(emailData, []string{user.GetEmail()}, conf.EmailHost.Username, subjectVerifyEmail)
+	if err != nil {
+		logger.Error(consts.CreateUserTag, consts.MsgErrEmailRequest, err.Error())
+		return userCreatedResponse, nil
+	}
+
+	if err := emailReq.sendEmail(templateVerifyEmail); err != nil {
+		logger.Error(consts.CreateUserTag, consts.MsgErrSendEmail, err.Error())
+	}
+
+	return userCreatedResponse, nil
 }
 
 // DeleteUser deletes a user row in accounts table.
@@ -711,7 +711,14 @@ func (s *Service) VerifyEmailToken(ctx context.Context, req *pbsvc.UserRequest) 
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	// TODO add uuid locker
+	uuid := auth.ExtractUUID(emailToken)
+	if uuid == "" {
+		return nil, consts.ErrStatusUUIDInvalid
+	}
+
+	lock, _ := uuidMapLocker.LoadOrStore(uuid, &sync.RWMutex{})
+	lock.(*sync.RWMutex).Lock()
+	defer lock.(*sync.RWMutex).Unlock()
 
 	// find matching email token row
 	retrievedToken, err := getEmailTokenRow(emailToken)

--- a/service/service.go
+++ b/service/service.go
@@ -172,7 +172,12 @@ func (s *Service) CreateUser(ctx context.Context, req *pbsvc.UserRequest) (*pbsv
 		logger.Error(consts.CreateUserTag, consts.MsgErrSendEmail, err.Error())
 	}
 
-	return userCreatedResponse, nil
+	return &pbsvc.UserResponse{
+		Status:         &pbsvc.UserResponse_Code{Code: uint32(codes.OK)},
+		Message:        codes.OK.String(),
+		Identification: &pblib.Identification{Token: emailID.GetToken()},
+		User:           user,
+	}, nil
 }
 
 // DeleteUser deletes a user row in accounts table.

--- a/service/test_fixtures/psql/0_initial_schemas.up.sql
+++ b/service/test_fixtures/psql/0_initial_schemas.up.sql
@@ -37,6 +37,7 @@ CREATE TABLE user_svc.accounts
 CREATE TABLE user_svc.email_tokens
 (
     token                TEXT PRIMARY KEY,
+    secret_key           TEXT NOT NULL,
     created_timestamp    TIMESTAMPTZ NOT NULL,
     expiration_timestamp TIMESTAMPTZ NOT NULL,
     uuid                 ulid UNIQUE REFERENCES user_svc.accounts (uuid) ON DELETE CASCADE

--- a/service/utility_test.go
+++ b/service/utility_test.go
@@ -120,6 +120,7 @@ func TestValidateUser(t *testing.T) {
 		{&invalidEmail, true, consts.ErrInvalidUserEmail.Error()},
 		{&invalidPassword, true, consts.ErrInvalidPassword.Error()},
 		{&invalidOrg, true, consts.ErrInvalidUserOrganization.Error()},
+		{nil, true, consts.ErrNilRequestUser.Error()},
 	}
 
 	for _, c := range cases {

--- a/service/utility_test.go
+++ b/service/utility_test.go
@@ -314,6 +314,29 @@ func TestComparePassword(t *testing.T) {
 	assert.EqualError(t, err, consts.ErrInvalidPassword.Error())
 }
 
+func TestGenerateEmailToken(t *testing.T) {
+	cases := []struct {
+		uuid       string
+		permission string
+		isExpError bool
+		expError   error
+	}{
+		{"", "", true, authconst.ErrInvalidUUID},
+		{"01d1na5ekzr7p98hragv5fmvx", "", true, authconst.ErrInvalidUUID},
+		{"01d3x3wm2nnrdfzp0tka2vw9dx", "", true, authconst.ErrInvalidPermission},
+		{"01d3x3wm2nnrdfzp0tka2vw9dx", "SuperAdmin", true, authconst.ErrInvalidPermission},
+		{"01d3x3wm2nnrdfzp0tka2vw9dx", "USER", false, nil},
+	}
+	for _, c := range cases {
+		id, err := generateEmailToken(c.uuid, c.permission)
+		if c.isExpError {
+			assert.EqualError(t, err, c.expError.Error())
+		} else {
+			assert.NotNil(t, id)
+		}
+	}
+}
+
 func TestGenerateSecretKey(t *testing.T) {
 	// NOTE: unable to force a race condition given the nature of randomByte used in generateEmailToken()
 	// but functionality is same as generateUUID and that's been tested for race conditions


### PR DESCRIPTION
Tasks:
- https://github.com/hwsc-org/hwsc-user-svc/issues/113
- https://github.com/hwsc-org/hwsc-user-svc/issues/108

CreateUser: https://hwsc-org.github.io/wikis/app-gateway-svc/epics.html#createuser
VerifyEmailToken: https://hwsc-org.github.io/wikis/app-gateway-svc/epics.html#verifyemailtoken

Allows generating of email token. `generateEmailToken` will be refactor to hwsc-lib in a different pull request and task.

Unit test: https://github.com/hwsc-org/hwsc-user-svc/pull/117/checks?check_run_id=89578202
Integration test: 
```
[SUCCESS] GetStatus - valid
[SUCCESS] CreateUser - valid
[SUCCESS] CreateUser - test null user
[SUCCESS] CreateUser - test empty user
[SUCCESS] GetUser - valid
[SUCCESS] GetUser - test non existent uuid
[SUCCESS] DeleteUser - valid, delete existing user
[SUCCESS] DeleteUser - test non existent uuid
[SUCCESS] UpdateUser - valid
[SUCCESS] UpdateUser - test non existent uuid
[SUCCESS] AuthenticateUser - valid
[SUCCESS] AuthenticateUser - test invalid UUID
[SUCCESS] NewSecret - test generating new secret
[SUCCESS] GetSecret - test retrieve active secret
[SUCCESS] GetToken - get token for user with no previous token
[SUCCESS] GetToken - get same/unexpired token for same user
[SUCCESS] VerifyAuthToken - get existing token paired with secret
[SUCCESS] VerifyEmailToken - verify existing token
[SUCCESS] VerifyEmailToken - test non-existing token
```