### PR TITLE
Return identification from AuthenticateUser

### DIFF
--- a/consts/errors.go
+++ b/consts/errors.go
@@ -75,4 +75,5 @@ var (
 	ErrStatusNilRequestUser     = status.Error(codes.InvalidArgument, ErrNilRequestUser.Error())
 	ErrStatusUUIDNotFound       = status.Error(codes.NotFound, ErrUUIDNotFound.Error())
 	ErrStatusUUIDInvalid        = status.Error(codes.InvalidArgument, authconst.ErrInvalidUUID.Error())
+	ErrStatusPermissionMismatch = status.Error(codes.Unauthenticated, MsgErrPermissionMismatch)
 )

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -543,6 +543,7 @@ func TestAuthenticateUser(t *testing.T) {
 		} else {
 			assert.Nil(t, err)
 			assert.Equal(t, codes.OK.String(), response.Message)
+			assert.NotNil(t, response.Identification)
 		}
 	}
 

--- a/service/utility_test.go
+++ b/service/utility_test.go
@@ -484,3 +484,49 @@ func TestGenerateEmailVerifyLink(t *testing.T) {
 	assert.Equal(t, manuallyBuiltLink, link, desc)
 	assert.Nil(t, err, desc)
 }
+
+func TestMakeAuthIdentification(t *testing.T) {
+	lastName1 := "GetToken-One"
+	lastName2 := "GetToken-Two"
+
+	// refresh secret table
+	retrievedSecret, err := unitTestDeleteInsertGetAuthSecret()
+	assert.Nil(t, err)
+	assert.NotNil(t, retrievedSecret)
+	currAuthSecret = retrievedSecret
+
+	// insert a user
+	responseUser1, err := unitTestInsertUser(lastName1)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, responseUser1)
+	responseUser1.GetUser().Password = lastName1
+
+	// insert another user to test setting of nil currAuthSecret
+	responseUser2, err := unitTestInsertUser(lastName2)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, responseUser2)
+	responseUser2.GetUser().Password = lastName2
+
+	cases := []struct {
+		user     *pblib.User
+		isExpErr bool
+		expMsg   string
+	}{
+		// valid
+		{responseUser1.GetUser(), false, ""},
+		{responseUser2.GetUser(), false, ""},
+		// nil user object
+		{nil, true, consts.ErrStatusNilRequestUser.Error()},
+	}
+	for _, c := range cases {
+		identification, err := getAuthIdentification(c.user)
+
+		if c.isExpErr {
+			assert.EqualError(t, err, c.expMsg)
+			assert.Nil(t, identification)
+		} else {
+			assert.Nil(t, err)
+			assert.NotNil(t, identification)
+		}
+	}
+}


### PR DESCRIPTION
This refactors getting Identification.
Additional unit testing is employed to get auth identification.
No integration test update is needed.
closes https://github.com/hwsc-org/hwsc-user-svc/issues/112