### PR TITLE
Rework GetAuthToken as GetNewAuthToken, and AuthenticateUser perm level

### DIFF
--- a/consts/errors.go
+++ b/consts/errors.go
@@ -11,10 +11,9 @@ import (
 const (
 	MsgErrInsertUser                string = "failed to insert new user into db:"
 	MsgErrInsertEmailToken          string = "failed to insert email token into db:"
-	MsgErrInsertAuthToken           string = "failed to insert auth token into db:"
 	MsgErrGeneratingUUID            string = "error in generating uuid:"
 	MsgErrGeneratingEmailToken      string = "error in generating email token:"
-	MsgErrGeneratingAuthToken       string = "error in generating auth token:"
+	MsgErrGeneratingAuthToken       string = "error in generating auth token"
 	MsgErrEmailRequest              string = "failed to make email request object:"
 	MsgErrSendEmail                 string = "failed to send email:"
 	MsgErrDeleteUser                string = "failed to delete user:"
@@ -64,8 +63,6 @@ var (
 	ErrInvalidAddTime               = errors.New("add time is zero")
 	ErrEmailExists                  = errors.New("email already exists")
 	ErrEmailDoesNotExist            = errors.New("email does not exist in db")
-	ErrGeneratingAuthToken          = errors.New(MsgErrGeneratingAuthToken)
-	ErrInsertAuthToken              = errors.New(MsgErrInsertAuthToken)
 	ResponseServiceUnavailable      = &pbsvc.UserResponse{
 		Status:  &pbsvc.UserResponse_Code{Code: uint32(codes.Unavailable)},
 		Message: codes.Unavailable.String(),

--- a/consts/errors.go
+++ b/consts/errors.go
@@ -20,10 +20,7 @@ const (
 	MsgErrDeleteUser                string = "failed to delete user:"
 	MsgErrGetUserRow                string = "failed to get user row:"
 	MsgErrUpdateUserRow             string = "failed to update user row:"
-	MsgErrAuthenticateUser          string = "failed to authenticate user:"
 	MsgErrMatchEmailPassword        string = "failed to match email and password in db:"
-	MsgErrMatchPassword             string = "failed to match password:"
-	MsgErrMatchEmail                string = "email does not match"
 	MsgErrSecret                    string = "failed to insert new secret into db:"
 	MsgErrGetActiveSecret           string = "failed to get active secret row from db:"
 	MsgErrLookUpActiveSecret        string = "failed to look up active secret from db"
@@ -67,6 +64,8 @@ var (
 	ErrInvalidAddTime               = errors.New("add time is zero")
 	ErrEmailExists                  = errors.New("email already exists")
 	ErrEmailDoesNotExist            = errors.New("email does not exist in db")
+	ErrGeneratingAuthToken          = errors.New(MsgErrGeneratingAuthToken)
+	ErrInsertAuthToken              = errors.New(MsgErrInsertAuthToken)
 	ResponseServiceUnavailable      = &pbsvc.UserResponse{
 		Status:  &pbsvc.UserResponse_Code{Code: uint32(codes.Unavailable)},
 		Message: codes.Unavailable.String(),

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/hwsc-org/hwsc-user-svc
 
 require (
 	github.com/Microsoft/go-winio v0.4.12 // indirect
+	github.com/Pallinder/go-randomdata v1.1.0
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect
@@ -9,8 +10,8 @@ require (
 	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/gorilla/mux v1.7.0 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
-	github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190526172357-abc2d60dfb0b
-	github.com/hwsc-org/hwsc-lib v0.0.0-20190401004322-783e42349378
+	github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190529032140-8ac00fb03e5d
+	github.com/hwsc-org/hwsc-lib v0.0.0-20190530220902-02694c12c0be
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/lib/pq v1.0.0
 	github.com/micro/go-config v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiU
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/Pallinder/go-randomdata v1.1.0 h1:gUubB1IEUliFmzjqjhf+bgkg1o6uoFIkRsP3VrhEcx8=
+github.com/Pallinder/go-randomdata v1.1.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -166,10 +168,10 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190310103314-d5245c3ac7ad h1:fWzDe74AMENol7oBM5beu8A6gr2MZDVfRDBlYuFnHBM=
 github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190310103314-d5245c3ac7ad/go.mod h1:/iVVgMsaXIOevC15fCsGWI0Dx2p6POFJQxeYbyjGst0=
-github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190526172357-abc2d60dfb0b h1:/8FfkgykFOKateOMlGJjb4XUC9VDevQHdDTmWg9f5qs=
-github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190526172357-abc2d60dfb0b/go.mod h1:/iVVgMsaXIOevC15fCsGWI0Dx2p6POFJQxeYbyjGst0=
-github.com/hwsc-org/hwsc-lib v0.0.0-20190401004322-783e42349378 h1:J2ADkUKYjEvOiwacTm8RXjpBThtd75Cg9Trv4zaORXE=
-github.com/hwsc-org/hwsc-lib v0.0.0-20190401004322-783e42349378/go.mod h1:x+Jk9oHb+7qbcHBKNUkJogQdM2D2BuLXbQ5wsGIiK4E=
+github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190529032140-8ac00fb03e5d h1:v46iIf6EWClh/yyKtn14VeygrFVzuF8Fyi7Jbpiaj2k=
+github.com/hwsc-org/hwsc-api-blocks v0.0.0-20190529032140-8ac00fb03e5d/go.mod h1:/iVVgMsaXIOevC15fCsGWI0Dx2p6POFJQxeYbyjGst0=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190530220902-02694c12c0be h1:c/+DcQb66rOkzxIGm//S/VaHLwpI/Sy5htGpnTK3Myk=
+github.com/hwsc-org/hwsc-lib v0.0.0-20190530220902-02694c12c0be/go.mod h1:x+Jk9oHb+7qbcHBKNUkJogQdM2D2BuLXbQ5wsGIiK4E=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/service/consts_test.go
+++ b/service/consts_test.go
@@ -18,12 +18,20 @@ var (
 		Organization: "Unit Testing",
 	}
 
-	validTokenHeader = &auth.Header{
+	validAuthTokenHeader = &auth.Header{
 		Alg:      auth.Hs256,
 		TokenTyp: auth.Jwt,
 	}
 
-	validTokenBody = &auth.Body{
+	validUUID, _ = generateUUID()
+
+	validAuthTokenBody = &auth.Body{
+		UUID:                validUUID,
+		Permission:          auth.User,
+		ExpirationTimestamp: time.Now().UTC().Add(time.Hour * time.Duration(authTokenExpirationTime)).Unix(),
+	}
+
+	validNoUUIDAuthTokenBody = &auth.Body{
 		Permission:          auth.User,
 		ExpirationTimestamp: time.Now().UTC().Add(time.Hour * time.Duration(authTokenExpirationTime)).Unix(),
 	}
@@ -97,16 +105,16 @@ func unitTestInsertNewAuthToken() (*pblib.Secret, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	validTokenBody.UUID = validUUID
+	validNoUUIDAuthTokenBody.UUID = validUUID
 
 	// generate new token
-	newToken, err := auth.NewToken(validTokenHeader, validTokenBody, newSecret)
+	newToken, err := auth.NewToken(validAuthTokenHeader, validNoUUIDAuthTokenBody, newSecret)
 	if err != nil {
 		return nil, "", err
 	}
 
 	// insert a token
-	if err := insertAuthToken(newToken, validTokenHeader, validTokenBody, newSecret); err != nil {
+	if err := insertAuthToken(newToken, validAuthTokenHeader, validNoUUIDAuthTokenBody, newSecret); err != nil {
 		return nil, "", err
 	}
 

--- a/service/db.go
+++ b/service/db.go
@@ -512,12 +512,13 @@ func getAuthTokenRow(uuid string) (*tokenAuthRow, error) {
 		return nil, authconst.ErrInvalidUUID
 	}
 
-	command := `SELECT uuid, permission, token, user_security.auth_tokens.secret_key, 
+	command := `SELECT DISTINCT ON (uuid) uuid, permission, token, user_security.auth_tokens.secret_key, 
        				user_security.secrets.created_timestamp, user_security.secrets.expiration_timestamp
 				FROM user_security.auth_tokens
 				INNER JOIN user_security.secrets
 				ON user_security.secrets.secret_key = user_security.auth_tokens.secret_key
 				WHERE uuid = $1 AND NOW() AT TIME ZONE 'UTC' < user_security.auth_tokens.expiration_timestamp
+				ORDER BY uuid, user_security.auth_tokens.expiration_timestamp DESC
 				`
 
 	row, err := postgresDB.Query(command, uuid)

--- a/service/db_test.go
+++ b/service/db_test.go
@@ -361,7 +361,7 @@ func TestInsertAuthToken(t *testing.T) {
 
 	uuid, err := generateUUID()
 	assert.Nil(t, err)
-	validTokenBody.UUID = uuid
+	validNoUUIDAuthTokenBody.UUID = uuid
 
 	cases := []struct {
 		body     *auth.Body
@@ -372,57 +372,57 @@ func TestInsertAuthToken(t *testing.T) {
 		expMsg   string
 	}{
 		// valid
-		{validTokenBody, currAuthSecret, validTokenHeader, token, false, ""},
+		{validNoUUIDAuthTokenBody, currAuthSecret, validAuthTokenHeader, token, false, ""},
 		// empty token
-		{validTokenBody, currAuthSecret, validTokenHeader, "", true, authconst.ErrEmptyToken.Error()},
+		{validNoUUIDAuthTokenBody, currAuthSecret, validAuthTokenHeader, "", true, authconst.ErrEmptyToken.Error()},
 		// nil header
-		{validTokenBody, currAuthSecret, nil, token, true, authconst.ErrNilHeader.Error()},
+		{validNoUUIDAuthTokenBody, currAuthSecret, nil, token, true, authconst.ErrNilHeader.Error()},
 		// nil body
-		{nil, currAuthSecret, validTokenHeader, token, true, authconst.ErrNilBody.Error()},
+		{nil, currAuthSecret, validAuthTokenHeader, token, true, authconst.ErrNilBody.Error()},
 		// nil secret
-		{validTokenBody, nil, validTokenHeader, token, true, authconst.ErrNilSecret.Error()},
+		{validNoUUIDAuthTokenBody, nil, validAuthTokenHeader, token, true, authconst.ErrNilSecret.Error()},
 		// body contains invalid UUID
 		{
 			&auth.Body{
 				UUID:                "invalid",
-				Permission:          validTokenBody.Permission,
-				ExpirationTimestamp: validTokenBody.ExpirationTimestamp,
-			}, currAuthSecret, validTokenHeader, token, true, authconst.ErrInvalidUUID.Error(),
+				Permission:          validNoUUIDAuthTokenBody.Permission,
+				ExpirationTimestamp: validNoUUIDAuthTokenBody.ExpirationTimestamp,
+			}, currAuthSecret, validAuthTokenHeader, token, true, authconst.ErrInvalidUUID.Error(),
 		},
 		// body contains invalid timestamp
 		{
 			&auth.Body{
-				UUID:                validTokenBody.UUID,
-				Permission:          validTokenBody.Permission,
+				UUID:                validNoUUIDAuthTokenBody.UUID,
+				Permission:          validNoUUIDAuthTokenBody.Permission,
 				ExpirationTimestamp: 12,
-			}, currAuthSecret, validTokenHeader, token, true, authconst.ErrExpiredBody.Error(),
+			}, currAuthSecret, validAuthTokenHeader, token, true, authconst.ErrExpiredBody.Error(),
 		},
 		// secret contains empty secret Key
 		{
-			validTokenBody,
+			validNoUUIDAuthTokenBody,
 			&pblib.Secret{
 				Key:                 "",
 				CreatedTimestamp:    currAuthSecret.CreatedTimestamp,
 				ExpirationTimestamp: currAuthSecret.ExpirationTimestamp,
-			}, validTokenHeader, token, true, authconst.ErrEmptySecret.Error(),
+			}, validAuthTokenHeader, token, true, authconst.ErrEmptySecret.Error(),
 		},
 		// secret contains createTimestamp greater than now
 		{
-			validTokenBody,
+			validNoUUIDAuthTokenBody,
 			&pblib.Secret{
 				Key:                 currAuthSecret.Key,
 				CreatedTimestamp:    currAuthSecret.ExpirationTimestamp,
 				ExpirationTimestamp: currAuthSecret.ExpirationTimestamp,
-			}, validTokenHeader, token, true, authconst.ErrInvalidSecretCreateTimestamp.Error(),
+			}, validAuthTokenHeader, token, true, authconst.ErrInvalidSecretCreateTimestamp.Error(),
 		},
 		// secret contains invalid expirationTimestamp
 		{
-			validTokenBody,
+			validNoUUIDAuthTokenBody,
 			&pblib.Secret{
 				Key:                 currAuthSecret.Key,
 				CreatedTimestamp:    currAuthSecret.CreatedTimestamp,
 				ExpirationTimestamp: 12,
-			}, validTokenHeader, token, true, authconst.ErrExpiredSecret.Error(),
+			}, validAuthTokenHeader, token, true, authconst.ErrExpiredSecret.Error(),
 		},
 	}
 
@@ -437,7 +437,7 @@ func TestInsertAuthToken(t *testing.T) {
 	}
 }
 
-func TestGetNewAuthTokenRow(t *testing.T) {
+func TestGetAuthTokenRow(t *testing.T) {
 	retrievedSecret, err := unitTestDeleteInsertGetAuthSecret()
 	assert.Nil(t, err)
 	assert.NotNil(t, retrievedSecret)
@@ -470,10 +470,10 @@ func TestGetNewAuthTokenRow(t *testing.T) {
 	}
 
 	// test valid with existing user
-	validTokenBody.UUID = validUUID
+	validNoUUIDAuthTokenBody.UUID = validUUID
 	// the above happens so fast that validating secret creation time fails b/c time == now()
 	time.Sleep(2 * time.Second)
-	err = insertAuthToken("TestRetrieveExistingToken", validTokenHeader, validTokenBody, retrievedSecret)
+	err = insertAuthToken("TestRetrieveExistingToken", validAuthTokenHeader, validNoUUIDAuthTokenBody, retrievedSecret)
 	assert.Nil(t, err)
 
 	retrievedToken, err := getAuthTokenRow(validUUID)

--- a/service/service.go
+++ b/service/service.go
@@ -507,57 +507,63 @@ func (s *Service) GetNewAuthToken(ctx context.Context, req *pbsvc.UserRequest) (
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	user := req.GetUser()
-	if user == nil {
-		return nil, consts.ErrStatusNilRequestUser
-	}
+	// TODO check Authenticate()
 
-	// validate uuid, email, password
-	if err := validation.ValidateUserUUID(user.GetUuid()); err != nil {
-		logger.Error(consts.GetNewAuthTokenTag, authconst.ErrInvalidUUID.Error())
-		return nil, consts.ErrStatusUUIDInvalid
-	}
-	if err := validateEmail(user.GetEmail()); err != nil {
-		logger.Error(consts.GetNewAuthTokenTag, consts.ErrInvalidUserEmail.Error())
-		return nil, status.Error(codes.InvalidArgument, consts.ErrInvalidUserEmail.Error())
-	}
-	if err := validatePassword(user.GetPassword()); err != nil {
-		logger.Error(consts.GetNewAuthTokenTag, consts.ErrInvalidPassword.Error())
-		return nil, status.Error(codes.InvalidArgument, consts.ErrInvalidPassword.Error())
-	}
-
-	// write lock b/c we are writing to DB
-	lock, _ := uuidMapLocker.LoadOrStore(user.GetUuid(), &sync.RWMutex{})
-	lock.(*sync.RWMutex).Lock()
-	defer lock.(*sync.RWMutex).Unlock()
-
-	// look up email and password
-	retrievedUser, err := getUserRow(user.GetUuid())
-	if err != nil {
-		logger.Error(consts.GetNewAuthTokenTag, consts.MsgErrAuthenticateUser, err.Error())
-		return nil, status.Error(codes.Unauthenticated, err.Error())
-	}
-
-	if retrievedUser.GetEmail() != user.GetEmail() {
-		logger.Error(consts.GetNewAuthTokenTag, consts.MsgErrMatchEmail)
-		return nil, status.Error(codes.InvalidArgument, consts.MsgErrMatchEmail)
-	}
-
-	if err := comparePassword(retrievedUser.GetPassword(), user.GetPassword()); err != nil {
-		logger.Error(consts.GetNewAuthTokenTag, consts.MsgErrMatchPassword, err.Error())
-		return nil, status.Error(codes.Unauthenticated, err.Error())
-	}
-
-	identification, err := getAuthIdentification(retrievedUser)
-	if err != nil {
-		logger.Error(consts.GetNewAuthTokenTag, err.Error())
-		return nil, err
-	}
-
+	//user := req.GetUser()
+	//if user == nil {
+	//	return nil, consts.ErrStatusNilRequestUser
+	//}
+	//
+	//// validate uuid, email, password
+	//if err := validation.ValidateUserUUID(user.GetUuid()); err != nil {
+	//	logger.Error(consts.GetNewAuthTokenTag, authconst.ErrInvalidUUID.Error())
+	//	return nil, consts.ErrStatusUUIDInvalid
+	//}
+	//if err := validateEmail(user.GetEmail()); err != nil {
+	//	logger.Error(consts.GetNewAuthTokenTag, consts.ErrInvalidUserEmail.Error())
+	//	return nil, status.Error(codes.InvalidArgument, consts.ErrInvalidUserEmail.Error())
+	//}
+	//if err := validatePassword(user.GetPassword()); err != nil {
+	//	logger.Error(consts.GetNewAuthTokenTag, consts.ErrInvalidPassword.Error())
+	//	return nil, status.Error(codes.InvalidArgument, consts.ErrInvalidPassword.Error())
+	//}
+	//
+	//// write lock b/c we are writing to DB
+	//lock, _ := uuidMapLocker.LoadOrStore(user.GetUuid(), &sync.RWMutex{})
+	//lock.(*sync.RWMutex).Lock()
+	//defer lock.(*sync.RWMutex).Unlock()
+	//
+	//// look up email and password
+	//retrievedUser, err := getUserRow(user.GetUuid())
+	//if err != nil {
+	//	logger.Error(consts.GetNewAuthTokenTag, consts.MsgErrAuthenticateUser, err.Error())
+	//	return nil, status.Error(codes.Unauthenticated, err.Error())
+	//}
+	//
+	//if retrievedUser.GetEmail() != user.GetEmail() {
+	//	logger.Error(consts.GetNewAuthTokenTag, consts.MsgErrMatchEmail)
+	//	return nil, status.Error(codes.InvalidArgument, consts.MsgErrMatchEmail)
+	//}
+	//
+	//if err := comparePassword(retrievedUser.GetPassword(), user.GetPassword()); err != nil {
+	//	logger.Error(consts.GetNewAuthTokenTag, consts.MsgErrMatchPassword, err.Error())
+	//	return nil, status.Error(codes.Unauthenticated, err.Error())
+	//}
+	//
+	//identification, err := getAuthIdentification(retrievedUser)
+	//if err != nil {
+	//	logger.Error(consts.GetNewAuthTokenTag, err.Error())
+	//	return nil, err
+	//}
+	//
+	//return &pbsvc.UserResponse{
+	//	Status:         &pbsvc.UserResponse_Code{Code: uint32(codes.OK)},
+	//	Message:        codes.OK.String(),
+	//	Identification: identification,
+	//}, nil
 	return &pbsvc.UserResponse{
-		Status:         &pbsvc.UserResponse_Code{Code: uint32(codes.OK)},
-		Message:        codes.OK.String(),
-		Identification: identification,
+		Status:  &pbsvc.UserResponse_Code{Code: uint32(codes.Unimplemented)},
+		Message: codes.Unimplemented.String(),
 	}, nil
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -347,7 +347,7 @@ func (s *Service) AuthenticateUser(ctx context.Context, req *pbsvc.UserRequest) 
 		logger.Error(consts.AuthenticateUserTag, consts.MsgErrMatchEmailPassword, err.Error())
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
-
+	// TODO do not authenticate based on permission level
 	identification, err := getAuthIdentification(matchedUser)
 	if err != nil {
 		logger.Error(consts.AuthenticateUserTag, err.Error())

--- a/service/service.go
+++ b/service/service.go
@@ -347,7 +347,11 @@ func (s *Service) AuthenticateUser(ctx context.Context, req *pbsvc.UserRequest) 
 		logger.Error(consts.AuthenticateUserTag, consts.MsgErrMatchEmailPassword, err.Error())
 		return nil, status.Error(codes.Unauthenticated, err.Error())
 	}
-	// TODO do not authenticate based on permission level
+
+	if auth.PermissionEnumMap[matchedUser.GetPermissionLevel()] < auth.UserRegistration {
+		logger.Error(consts.AuthenticateUserTag, consts.MsgErrGeneratingAuthToken)
+		return nil, status.Error(codes.Unauthenticated, consts.MsgErrGeneratingAuthToken)
+	}
 	identification, err := getAuthIdentification(matchedUser)
 	if err != nil {
 		logger.Error(consts.AuthenticateUserTag, err.Error())

--- a/service/service.go
+++ b/service/service.go
@@ -554,8 +554,8 @@ func (s *Service) GetNewAuthToken(ctx context.Context, req *pbsvc.UserRequest) (
 	}
 
 	return &pbsvc.UserResponse{
-		Status:         &pbsvc.UserResponse_Code{Code: uint32(codes.Unimplemented)},
-		Message:        codes.Unimplemented.String(),
+		Status:         &pbsvc.UserResponse_Code{Code: uint32(codes.OK)},
+		Message:        codes.OK.String(),
 		Identification: newIdentity,
 	}, nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -506,7 +506,7 @@ func (s *Service) GetNewAuthToken(ctx context.Context, req *pbsvc.UserRequest) (
 
 	if req == nil {
 		logger.Error(consts.GetNewAuthTokenTag, consts.ErrNilRequest.Error())
-		return nil, consts.ErrNilRequest
+		return nil, consts.ErrStatusNilRequestUser
 	}
 
 	if err := refreshDBConnection(); err != nil {
@@ -572,10 +572,12 @@ func (s *Service) VerifyAuthToken(ctx context.Context, req *pbsvc.UserRequest) (
 	}
 
 	if req == nil {
+		logger.Error(consts.VerifyAuthToken, consts.ErrNilRequest.Error())
 		return nil, consts.ErrStatusNilRequestUser
 	}
 
 	if err := refreshDBConnection(); err != nil {
+		logger.Error(consts.VerifyAuthToken, consts.ErrDBConnectionError.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
@@ -621,6 +623,7 @@ func (s *Service) MakeNewAuthSecret(ctx context.Context, req *pbsvc.UserRequest)
 	}
 
 	if err := refreshDBConnection(); err != nil {
+		logger.Error(consts.MakeNewAuthSecret, consts.ErrDBConnectionError.Error())
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -661,8 +661,8 @@ func TestGetNewAuthToken(t *testing.T) {
 	assert.Nil(t, err, validCase)
 	assert.NotNil(t, resp, validCase)
 
-	time.Sleep(2 * time.Second)
 	// make new auth token
+	time.Sleep(2 * time.Second)
 	resp.GetIdentification().GetToken()
 	resp, err = s.GetNewAuthToken(context.TODO(), &pbsvc.UserRequest{Identification: oldValidIdentification})
 	assert.Nil(t, err, validCase)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -715,8 +715,7 @@ func TestGetNewAuthToken(t *testing.T) {
 
 	for _, c := range cases {
 		s := Service{}
-
-		response, err := s.MakeNewAuthSecret(context.TODO(), c.req)
+		response, err := s.GetNewAuthToken(context.TODO(), c.req)
 		assert.EqualError(t, err, c.expMsg, c.desc)
 		assert.Nil(t, response, c.desc)
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -706,10 +706,10 @@ func TestGetNewAuthToken(t *testing.T) {
 			"rpc error: code = InvalidArgument desc = nil request User",
 		},
 		{"test nil identity object", &pbsvc.UserRequest{Identification: nil},
-			"rpc error: code = InvalidArgument desc = nil request identification",
+			"rpc error: code = DeadlineExceeded desc = nil request identification",
 		},
 		{"test non-existent token", &pbsvc.UserRequest{Identification: nonExistingToken},
-			"rpc error: code = Unauthenticated desc = no matching auth token were found with given token",
+			"rpc error: code = DeadlineExceeded desc = no matching auth token were found with given token",
 		},
 	}
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -624,107 +624,107 @@ func TestGetAuthSecret(t *testing.T) {
 }
 
 func TestGetNewAuthToken(t *testing.T) {
-	lastName1 := "GetToken-One"
-	lastName2 := "GetToken-Two"
-
-	// refresh secret table
-	retrievedSecret, err := unitTestDeleteInsertGetAuthSecret()
-	assert.Nil(t, err)
-	assert.NotNil(t, retrievedSecret)
-	currAuthSecret = retrievedSecret
-
-	// insert a user
-	responseUser1, err := unitTestInsertUser(lastName1)
-	assert.Nil(t, err)
-	assert.NotEmpty(t, responseUser1)
-	responseUser1.GetUser().Password = lastName1
-
-	// insert another user to test setting of nil currAuthSecret
-	responseUser2, err := unitTestInsertUser(lastName2)
-	assert.Nil(t, err)
-	assert.NotEmpty(t, responseUser2)
-	responseUser2.GetUser().Password = lastName2
-
-	cases := []struct {
-		request  *pbsvc.UserRequest
-		isExpErr bool
-		expMsg   string
-	}{
-		// valid
-		{&pbsvc.UserRequest{User: responseUser1.GetUser()}, false, ""},
-		// valid - test setting of nil currAuthSecret to active secret retrieved from db
-		{&pbsvc.UserRequest{User: responseUser2.GetUser()}, false, ""},
-		// nil request object
-		{nil, true, "rpc error: code = InvalidArgument desc = nil request User"},
-		// nil user object
-		{&pbsvc.UserRequest{User: nil}, true, "rpc error: code = InvalidArgument desc = nil request User"},
-		// user contains invalid uuid
-		{&pbsvc.UserRequest{
-			User: &pblib.User{
-				Uuid:     "invalid",
-				Email:    responseUser1.GetUser().GetEmail(),
-				Password: responseUser1.GetUser().GetPassword(),
-			}},
-			true, "rpc error: code = InvalidArgument desc = invalid uuid",
-		},
-		// user contains invalid email
-		{&pbsvc.UserRequest{
-			User: &pblib.User{
-				Uuid:     responseUser1.GetUser().GetUuid(),
-				Email:    "@",
-				Password: responseUser1.GetUser().GetPassword(),
-			}},
-			true, "rpc error: code = InvalidArgument desc = invalid User email",
-		},
-		// user contains invalid password
-		{&pbsvc.UserRequest{
-			User: &pblib.User{
-				Uuid:     responseUser1.GetUser().GetUuid(),
-				Email:    responseUser1.GetUser().GetEmail(),
-				Password: "",
-			}},
-			true, "rpc error: code = InvalidArgument desc = invalid User password",
-		},
-	}
-
-	var existingIdentification *pblib.Identification
-	for index, c := range cases {
-		s := Service{}
-		if index == 1 {
-			// test setting of nil currAuthSecret to active secret retrieved from db
-			currAuthSecret = nil
-		}
-		response, err := s.GetNewAuthToken(context.TODO(), c.request)
-
-		if c.isExpErr {
-			assert.EqualError(t, err, c.expMsg)
-			assert.Nil(t, response)
-		} else if index == 1 {
-			desc := "test setting of nil currAuthSecret to active secret retrieved from db"
-			assert.Nil(t, err, desc)
-			assert.Equal(t, codes.OK.String(), response.GetMessage(), desc)
-			assert.Equal(t, response.GetIdentification().GetSecret().GetKey(), retrievedSecret.GetKey(), desc)
-		} else {
-			existingIdentification = response.GetIdentification()
-			assert.Nil(t, err)
-			assert.Equal(t, codes.OK.String(), response.GetMessage())
-			assert.NotEmpty(t, response.GetIdentification())
-			assert.NotEmpty(t, response.GetIdentification().GetSecret())
-			assert.NotEmpty(t, response.GetIdentification().GetToken())
-		}
-	}
-
-	// check for retrieval of same token already in db
-	s := Service{}
-	response, err := s.GetNewAuthToken(context.TODO(), &pbsvc.UserRequest{User: responseUser1.GetUser()})
-	assert.Nil(t, err)
-	assert.Exactly(t, existingIdentification, response.GetIdentification())
-	assert.Equal(t, existingIdentification.GetToken(), response.GetIdentification().GetToken())
-
-	secret := response.GetIdentification().GetSecret()
-	assert.Equal(t, existingIdentification.GetSecret().GetKey(), secret.GetKey())
-	assert.Equal(t, existingIdentification.GetSecret().GetCreatedTimestamp(), secret.GetCreatedTimestamp())
-	assert.Equal(t, existingIdentification.GetSecret().GetExpirationTimestamp(), secret.GetExpirationTimestamp())
+	//lastName1 := "GetToken-One"
+	//lastName2 := "GetToken-Two"
+	//
+	//// refresh secret table
+	//retrievedSecret, err := unitTestDeleteInsertGetAuthSecret()
+	//assert.Nil(t, err)
+	//assert.NotNil(t, retrievedSecret)
+	//currAuthSecret = retrievedSecret
+	//
+	//// insert a user
+	//responseUser1, err := unitTestInsertUser(lastName1)
+	//assert.Nil(t, err)
+	//assert.NotEmpty(t, responseUser1)
+	//responseUser1.GetUser().Password = lastName1
+	//
+	//// insert another user to test setting of nil currAuthSecret
+	//responseUser2, err := unitTestInsertUser(lastName2)
+	//assert.Nil(t, err)
+	//assert.NotEmpty(t, responseUser2)
+	//responseUser2.GetUser().Password = lastName2
+	//
+	//cases := []struct {
+	//	request  *pbsvc.UserRequest
+	//	isExpErr bool
+	//	expMsg   string
+	//}{
+	//	// valid
+	//	{&pbsvc.UserRequest{User: responseUser1.GetUser()}, false, ""},
+	//	// valid - test setting of nil currAuthSecret to active secret retrieved from db
+	//	{&pbsvc.UserRequest{User: responseUser2.GetUser()}, false, ""},
+	//	// nil request object
+	//	{nil, true, "rpc error: code = InvalidArgument desc = nil request User"},
+	//	// nil user object
+	//	{&pbsvc.UserRequest{User: nil}, true, "rpc error: code = InvalidArgument desc = nil request User"},
+	//	// user contains invalid uuid
+	//	{&pbsvc.UserRequest{
+	//		User: &pblib.User{
+	//			Uuid:     "invalid",
+	//			Email:    responseUser1.GetUser().GetEmail(),
+	//			Password: responseUser1.GetUser().GetPassword(),
+	//		}},
+	//		true, "rpc error: code = InvalidArgument desc = invalid uuid",
+	//	},
+	//	// user contains invalid email
+	//	{&pbsvc.UserRequest{
+	//		User: &pblib.User{
+	//			Uuid:     responseUser1.GetUser().GetUuid(),
+	//			Email:    "@",
+	//			Password: responseUser1.GetUser().GetPassword(),
+	//		}},
+	//		true, "rpc error: code = InvalidArgument desc = invalid User email",
+	//	},
+	//	// user contains invalid password
+	//	{&pbsvc.UserRequest{
+	//		User: &pblib.User{
+	//			Uuid:     responseUser1.GetUser().GetUuid(),
+	//			Email:    responseUser1.GetUser().GetEmail(),
+	//			Password: "",
+	//		}},
+	//		true, "rpc error: code = InvalidArgument desc = invalid User password",
+	//	},
+	//}
+	//
+	//var existingIdentification *pblib.Identification
+	//for index, c := range cases {
+	//	s := Service{}
+	//	if index == 1 {
+	//		// test setting of nil currAuthSecret to active secret retrieved from db
+	//		currAuthSecret = nil
+	//	}
+	//	response, err := s.GetNewAuthToken(context.TODO(), c.request)
+	//
+	//	if c.isExpErr {
+	//		assert.EqualError(t, err, c.expMsg)
+	//		assert.Nil(t, response)
+	//	} else if index == 1 {
+	//		desc := "test setting of nil currAuthSecret to active secret retrieved from db"
+	//		assert.Nil(t, err, desc)
+	//		assert.Equal(t, codes.OK.String(), response.GetMessage(), desc)
+	//		assert.Equal(t, response.GetIdentification().GetSecret().GetKey(), retrievedSecret.GetKey(), desc)
+	//	} else {
+	//		existingIdentification = response.GetIdentification()
+	//		assert.Nil(t, err)
+	//		assert.Equal(t, codes.OK.String(), response.GetMessage())
+	//		assert.NotEmpty(t, response.GetIdentification())
+	//		assert.NotEmpty(t, response.GetIdentification().GetSecret())
+	//		assert.NotEmpty(t, response.GetIdentification().GetToken())
+	//	}
+	//}
+	//
+	//// check for retrieval of same token already in db
+	//s := Service{}
+	//response, err := s.GetNewAuthToken(context.TODO(), &pbsvc.UserRequest{User: responseUser1.GetUser()})
+	//assert.Nil(t, err)
+	//assert.Exactly(t, existingIdentification, response.GetIdentification())
+	//assert.Equal(t, existingIdentification.GetToken(), response.GetIdentification().GetToken())
+	//
+	//secret := response.GetIdentification().GetSecret()
+	//assert.Equal(t, existingIdentification.GetSecret().GetKey(), secret.GetKey())
+	//assert.Equal(t, existingIdentification.GetSecret().GetCreatedTimestamp(), secret.GetCreatedTimestamp())
+	//assert.Equal(t, existingIdentification.GetSecret().GetExpirationTimestamp(), secret.GetExpirationTimestamp())
 }
 
 func TestVerifyAuthToken(t *testing.T) {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"database/sql"
 	"fmt"
+	"github.com/Pallinder/go-randomdata"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -624,107 +625,66 @@ func TestGetAuthSecret(t *testing.T) {
 }
 
 func TestGetNewAuthToken(t *testing.T) {
-	//lastName1 := "GetToken-One"
-	//lastName2 := "GetToken-Two"
-	//
-	//// refresh secret table
-	//retrievedSecret, err := unitTestDeleteInsertGetAuthSecret()
-	//assert.Nil(t, err)
-	//assert.NotNil(t, retrievedSecret)
-	//currAuthSecret = retrievedSecret
-	//
-	//// insert a user
-	//responseUser1, err := unitTestInsertUser(lastName1)
-	//assert.Nil(t, err)
-	//assert.NotEmpty(t, responseUser1)
-	//responseUser1.GetUser().Password = lastName1
-	//
-	//// insert another user to test setting of nil currAuthSecret
-	//responseUser2, err := unitTestInsertUser(lastName2)
-	//assert.Nil(t, err)
-	//assert.NotEmpty(t, responseUser2)
-	//responseUser2.GetUser().Password = lastName2
-	//
-	//cases := []struct {
-	//	request  *pbsvc.UserRequest
-	//	isExpErr bool
-	//	expMsg   string
-	//}{
-	//	// valid
-	//	{&pbsvc.UserRequest{User: responseUser1.GetUser()}, false, ""},
-	//	// valid - test setting of nil currAuthSecret to active secret retrieved from db
-	//	{&pbsvc.UserRequest{User: responseUser2.GetUser()}, false, ""},
-	//	// nil request object
-	//	{nil, true, "rpc error: code = InvalidArgument desc = nil request User"},
-	//	// nil user object
-	//	{&pbsvc.UserRequest{User: nil}, true, "rpc error: code = InvalidArgument desc = nil request User"},
-	//	// user contains invalid uuid
-	//	{&pbsvc.UserRequest{
-	//		User: &pblib.User{
-	//			Uuid:     "invalid",
-	//			Email:    responseUser1.GetUser().GetEmail(),
-	//			Password: responseUser1.GetUser().GetPassword(),
-	//		}},
-	//		true, "rpc error: code = InvalidArgument desc = invalid uuid",
-	//	},
-	//	// user contains invalid email
-	//	{&pbsvc.UserRequest{
-	//		User: &pblib.User{
-	//			Uuid:     responseUser1.GetUser().GetUuid(),
-	//			Email:    "@",
-	//			Password: responseUser1.GetUser().GetPassword(),
-	//		}},
-	//		true, "rpc error: code = InvalidArgument desc = invalid User email",
-	//	},
-	//	// user contains invalid password
-	//	{&pbsvc.UserRequest{
-	//		User: &pblib.User{
-	//			Uuid:     responseUser1.GetUser().GetUuid(),
-	//			Email:    responseUser1.GetUser().GetEmail(),
-	//			Password: "",
-	//		}},
-	//		true, "rpc error: code = InvalidArgument desc = invalid User password",
-	//	},
-	//}
-	//
-	//var existingIdentification *pblib.Identification
-	//for index, c := range cases {
-	//	s := Service{}
-	//	if index == 1 {
-	//		// test setting of nil currAuthSecret to active secret retrieved from db
-	//		currAuthSecret = nil
-	//	}
-	//	response, err := s.GetNewAuthToken(context.TODO(), c.request)
-	//
-	//	if c.isExpErr {
-	//		assert.EqualError(t, err, c.expMsg)
-	//		assert.Nil(t, response)
-	//	} else if index == 1 {
-	//		desc := "test setting of nil currAuthSecret to active secret retrieved from db"
-	//		assert.Nil(t, err, desc)
-	//		assert.Equal(t, codes.OK.String(), response.GetMessage(), desc)
-	//		assert.Equal(t, response.GetIdentification().GetSecret().GetKey(), retrievedSecret.GetKey(), desc)
-	//	} else {
-	//		existingIdentification = response.GetIdentification()
-	//		assert.Nil(t, err)
-	//		assert.Equal(t, codes.OK.String(), response.GetMessage())
-	//		assert.NotEmpty(t, response.GetIdentification())
-	//		assert.NotEmpty(t, response.GetIdentification().GetSecret())
-	//		assert.NotEmpty(t, response.GetIdentification().GetToken())
-	//	}
-	//}
-	//
-	//// check for retrieval of same token already in db
-	//s := Service{}
-	//response, err := s.GetNewAuthToken(context.TODO(), &pbsvc.UserRequest{User: responseUser1.GetUser()})
-	//assert.Nil(t, err)
-	//assert.Exactly(t, existingIdentification, response.GetIdentification())
-	//assert.Equal(t, existingIdentification.GetToken(), response.GetIdentification().GetToken())
-	//
-	//secret := response.GetIdentification().GetSecret()
-	//assert.Equal(t, existingIdentification.GetSecret().GetKey(), secret.GetKey())
-	//assert.Equal(t, existingIdentification.GetSecret().GetCreatedTimestamp(), secret.GetCreatedTimestamp())
-	//assert.Equal(t, existingIdentification.GetSecret().GetExpirationTimestamp(), secret.GetExpirationTimestamp())
+	// test registration -> authenticate -> new auth token -> authenticate
+	// register
+	validCase := "test registration -> authenticate -> new auth token -> authenticate"
+	userResp, err := unitTestInsertUser(randomdata.LastName())
+	assert.Nil(t, err, validCase)
+	assert.Equal(t, codes.OK.String(), userResp.GetMessage(), validCase)
+	validUser := userResp.GetUser()
+
+	// verify email token
+	s := Service{}
+	resp, err := s.VerifyEmailToken(context.TODO(), &pbsvc.UserRequest{
+		Identification: &pblib.Identification{Token: userResp.GetIdentification().GetToken()},
+	})
+	assert.Nil(t, err, validCase)
+	assert.NotNil(t, resp, validCase)
+
+	// authenticate
+	req := &pbsvc.UserRequest{
+		User: &pblib.User{
+			Email:    validUser.GetEmail(),
+			Password: validUser.GetLastName(),
+		},
+	}
+	resp, err = s.AuthenticateUser(context.TODO(), req)
+	assert.Nil(t, err, validCase)
+	assert.NotNil(t, resp, validCase)
+	oldAuthToken := resp.GetIdentification().GetToken()
+	oldValidIdentification := &pblib.Identification{
+		Token: oldAuthToken,
+	}
+
+	// valid auth token
+	resp, err = s.VerifyAuthToken(context.TODO(), &pbsvc.UserRequest{Identification: oldValidIdentification})
+	assert.Nil(t, err, validCase)
+	assert.NotNil(t, resp, validCase)
+
+	time.Sleep(2 * time.Second)
+	// make new auth token
+	resp.GetIdentification().GetToken()
+	resp, err = s.GetNewAuthToken(context.TODO(), &pbsvc.UserRequest{Identification: oldValidIdentification})
+	assert.Nil(t, err, validCase)
+	assert.NotNil(t, resp, validCase)
+	// assert old auth token not equal new auth token
+	newAuthToken := resp.GetIdentification().GetToken()
+	assert.NotEqual(t, oldAuthToken, newAuthToken, validCase)
+	newValidIdentification := &pblib.Identification{
+		Token: newAuthToken,
+	}
+
+	// old auth token should still be valid
+	resp, err = s.VerifyAuthToken(context.TODO(), &pbsvc.UserRequest{Identification: oldValidIdentification})
+	assert.Nil(t, err, validCase)
+	assert.Equal(t, codes.OK.String(), resp.GetMessage(), validCase)
+
+	// new auth token should be valid
+	resp, err = s.VerifyAuthToken(context.TODO(), &pbsvc.UserRequest{Identification: newValidIdentification})
+	assert.Nil(t, err, validCase)
+	assert.Equal(t, codes.OK.String(), resp.GetMessage(), validCase)
+
+	// TODO error cases
 }
 
 func TestVerifyAuthToken(t *testing.T) {


### PR DESCRIPTION
Task: https://github.com/hwsc-org/hwsc-user-svc/issues/114

Contains the following changes:
`AuthenticateUser` only authenticates at a minimum of `UserRegistration` permission level.
Fix missing logging.
Update unit tests.